### PR TITLE
feat: add JDBC and Azure Service Bus logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 ## 🚀 Características Principais
 
 - **Logs Estruturados JSON**: Todos os logs são emitidos em formato JSON para fácil ingestão em plataformas de observabilidade
-- **Correlação Ponta-a-Ponta**: Propagação automática de `correlationId` através de HTTP, Kafka, MongoDB e outros
+- **Correlação Ponta-a-Ponta**: Propagação automática de `correlationId` através de HTTP, Kafka, MongoDB, JDBC, Service Bus e outros
 - **AOP Automático**: Logging transparente com anotações `@Loggable` e `@BusinessEvent`
 - **Redação de PII**: Mascaramento automático de dados sensíveis baseado em configuração
-- **Conectores Plug-and-Play**: Suporte automático para HTTP, Kafka, MongoDB conforme dependências no classpath
+- **Conectores Plug-and-Play**: Suporte automático para HTTP, Kafka, MongoDB, JDBC e Azure Service Bus conforme dependências no classpath
 - **Performance**: Overhead <2% CPU com sampling inteligente e appenders assíncronos
 
 ## 📦 Instalação
@@ -72,6 +72,17 @@ loggingx:
     enabled: true
     slow-queries-only: true
     slow-threshold-ms: 1000
+
+  # Configurações Azure Service Bus
+  servicebus:
+    enabled: true
+    log-payload: false
+
+  # Configurações JDBC
+  jdbc:
+    enabled: false
+    slow-queries-only: true
+    slow-threshold-ms: 500
 ```
 
 ## 📝 Uso Básico

--- a/pom.xml
+++ b/pom.xml
@@ -82,18 +82,34 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- (Opcional) Mongo command listener -->
-		<dependency>
-			<groupId>org.mongodb</groupId>
-			<artifactId>mongodb-driver-core</artifactId>
-			<version>5.1.2</version>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <!-- (Opcional) Mongo command listener -->
+                <dependency>
+                        <groupId>org.mongodb</groupId>
+                        <artifactId>mongodb-driver-core</artifactId>
+                        <version>5.1.2</version>
+                        <optional>true</optional>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-mongodb</artifactId>
+                        <optional>true</optional>
+                </dependency>
+
+                <!-- (Opcional) Azure Service Bus -->
+                <dependency>
+                        <groupId>com.azure</groupId>
+                        <artifactId>azure-messaging-servicebus</artifactId>
+                        <version>7.15.0</version>
+                        <optional>true</optional>
+                </dependency>
+
+                <!-- (Opcional) JDBC DataSource proxy -->
+                <dependency>
+                        <groupId>net.ttddyy</groupId>
+                        <artifactId>datasource-proxy</artifactId>
+                        <version>1.9</version>
+                        <optional>true</optional>
+                </dependency>
 
 		<!-- (Opcional) Encoder JSON logback -->
 		<dependency>

--- a/src/main/java/com/hlaff/loggingx/jdbc/LoggingDataSourceProxyBeanPostProcessor.java
+++ b/src/main/java/com/hlaff/loggingx/jdbc/LoggingDataSourceProxyBeanPostProcessor.java
@@ -1,0 +1,36 @@
+package com.hlaff.loggingx.jdbc;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import javax.sql.DataSource;
+
+/**
+ * BeanPostProcessor que envolve DataSources com ProxyDataSource para
+ * interceptar execuções de SQL e delegar ao listener de logging.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class LoggingDataSourceProxyBeanPostProcessor implements BeanPostProcessor {
+
+    private final LoggingQueryExecutionListener listener;
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof DataSource dataSource) {
+            try {
+                return ProxyDataSourceBuilder.create(dataSource)
+                        .name(beanName)
+                        .listener(listener)
+                        .build();
+            } catch (Exception e) {
+                log.debug("Falha ao criar ProxyDataSource para {}: {}", beanName, e.getMessage());
+            }
+        }
+        return bean;
+    }
+}
+

--- a/src/main/java/com/hlaff/loggingx/jdbc/LoggingQueryExecutionListener.java
+++ b/src/main/java/com/hlaff/loggingx/jdbc/LoggingQueryExecutionListener.java
@@ -1,0 +1,113 @@
+package com.hlaff.loggingx.jdbc;
+
+import com.hlaff.loggingx.core.logger.StructuredLogger;
+import com.hlaff.loggingx.spring.config.LoggingXProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+
+import java.util.List;
+
+/**
+ * Listener de execução de queries JDBC que gera logs estruturados
+ * para statements SQL.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class LoggingQueryExecutionListener implements QueryExecutionListener {
+
+    private final StructuredLogger structuredLogger;
+    private final LoggingXProperties properties;
+
+    @Override
+    public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        if (!properties.getJdbc().isLogStatements()) {
+            return;
+        }
+
+        try {
+            for (QueryInfo queryInfo : queryInfoList) {
+                String sql = queryInfo.getQuery();
+                structuredLogger.debug(event -> {
+                    event.component("jdbc")
+                         .dbSystem("sql")
+                         .dbOperation(extractOperation(sql))
+                         .put("db.statement", sql);
+
+                    if (properties.getJdbc().isLogParameters()) {
+                        event.put("db.parameters", queryInfo.getParametersList().toString());
+                    }
+
+                    event.sampled(true);
+                });
+            }
+        } catch (Exception e) {
+            log.debug("Erro ao logar início de query JDBC: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        long duration = execInfo.getElapsedTime();
+
+        if (properties.getJdbc().isSlowQueriesOnly() &&
+            duration < properties.getJdbc().getSlowThresholdMs()) {
+            return;
+        }
+
+        try {
+            for (QueryInfo queryInfo : queryInfoList) {
+                String sql = queryInfo.getQuery();
+                if (execInfo.getThrowable() == null) {
+                    structuredLogger.info(event -> {
+                        event.component("jdbc")
+                             .dbSystem("sql")
+                             .dbOperation(extractOperation(sql))
+                             .durationMs(duration)
+                             .put("db.statement", sql);
+
+                        if (properties.getJdbc().isLogParameters()) {
+                            event.put("db.parameters", queryInfo.getParametersList().toString());
+                        }
+
+                        event.sampled(true);
+                    });
+                } else {
+                    structuredLogger.error(event -> {
+                        event.component("jdbc")
+                             .dbSystem("sql")
+                             .dbOperation(extractOperation(sql))
+                             .durationMs(duration)
+                             .put("db.statement", sql)
+                             .errorKind(execInfo.getThrowable().getClass().getSimpleName())
+                             .errorMessage(execInfo.getThrowable().getMessage());
+
+                        if (properties.isIncludeStacktrace()) {
+                            event.error(execInfo.getThrowable());
+                        }
+
+                        if (properties.getJdbc().isLogParameters()) {
+                            event.put("db.parameters", queryInfo.getParametersList().toString());
+                        }
+
+                        event.sampled(true);
+                    });
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Erro ao logar execução de query JDBC: {}", e.getMessage());
+        }
+    }
+
+    private String extractOperation(String sql) {
+        if (sql == null) {
+            return null;
+        }
+        String trimmed = sql.trim();
+        int idx = trimmed.indexOf(' ');
+        return idx > 0 ? trimmed.substring(0, idx).toLowerCase() : trimmed.toLowerCase();
+    }
+}
+

--- a/src/main/java/com/hlaff/loggingx/servicebus/ServiceBusLoggingHelper.java
+++ b/src/main/java/com/hlaff/loggingx/servicebus/ServiceBusLoggingHelper.java
@@ -1,0 +1,108 @@
+package com.hlaff.loggingx.servicebus;
+
+import com.azure.messaging.servicebus.ServiceBusErrorContext;
+import com.azure.messaging.servicebus.ServiceBusMessage;
+import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
+import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import com.hlaff.loggingx.core.logger.StructuredLogger;
+import com.hlaff.loggingx.spring.config.LoggingXProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Helper para logging estruturado de eventos do Azure Service Bus.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ServiceBusLoggingHelper {
+
+    private final StructuredLogger structuredLogger;
+    private final LoggingXProperties properties;
+
+    /**
+     * Loga envio de mensagem pelo Service Bus Sender.
+     */
+    public void logProducerSend(ServiceBusSenderClient sender, ServiceBusMessage message) {
+        if (!properties.getServicebus().isLogProducer()) {
+            return;
+        }
+
+        try {
+            structuredLogger.info(event -> {
+                event.component("servicebus-producer")
+                     .topic(sender.getEntityName())
+                     .put("messageId", message.getMessageId())
+                     .put("correlationId", message.getCorrelationId());
+
+                if (properties.getServicebus().isLogPayload() && message.getBody() != null) {
+                    event.put("payload", message.getBody().toString());
+                }
+
+                if (properties.getServicebus().isLogApplicationProperties() &&
+                    message.getApplicationProperties() != null && !message.getApplicationProperties().isEmpty()) {
+                    event.put("applicationProperties", message.getApplicationProperties());
+                }
+
+                event.sampled(true);
+            });
+        } catch (Exception e) {
+            log.debug("Erro ao logar envio Service Bus: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Loga recebimento de mensagem pelo Service Bus.
+     */
+    public void logConsumerReceive(String entity, ServiceBusReceivedMessage message) {
+        if (!properties.getServicebus().isLogConsumer()) {
+            return;
+        }
+
+        try {
+            structuredLogger.info(event -> {
+                event.component("servicebus-consumer")
+                     .topic(entity)
+                     .put("messageId", message.getMessageId())
+                     .put("correlationId", message.getCorrelationId());
+
+                if (properties.getServicebus().isLogPayload() && message.getBody() != null) {
+                    event.put("payload", message.getBody().toString());
+                }
+
+                if (properties.getServicebus().isLogApplicationProperties() &&
+                    message.getApplicationProperties() != null && !message.getApplicationProperties().isEmpty()) {
+                    event.put("applicationProperties", message.getApplicationProperties());
+                }
+
+                event.sampled(true);
+            });
+        } catch (Exception e) {
+            log.debug("Erro ao logar recebimento Service Bus: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Loga erros de processamento do Service Bus.
+     */
+    public void logProcessError(ServiceBusErrorContext context) {
+        try {
+            structuredLogger.error(event -> {
+                event.component("servicebus")
+                     .topic(context.getEntityPath())
+                     .errorKind(context.getException().getClass().getSimpleName())
+                     .errorMessage(context.getException().getMessage());
+
+                if (properties.isIncludeStacktrace()) {
+                    event.error(context.getException());
+                }
+
+                event.sampled(true);
+            });
+        } catch (Exception e) {
+            log.debug("Erro ao logar erro Service Bus: {}", e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/hlaff/loggingx/spring/config/LoggingXAutoConfiguration.java
+++ b/src/main/java/com/hlaff/loggingx/spring/config/LoggingXAutoConfiguration.java
@@ -182,6 +182,20 @@ public class LoggingXAutoConfiguration {
     }
 
     // ========================================
+    // CONECTORES AZURE SERVICE BUS
+    // ========================================
+
+    @Bean
+    @ConditionalOnClass(com.azure.messaging.servicebus.ServiceBusClientBuilder.class)
+    @ConditionalOnProperty(prefix = "loggingx.servicebus", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnMissingBean
+    public com.hlaff.loggingx.servicebus.ServiceBusLoggingHelper serviceBusLoggingHelper(StructuredLogger structuredLogger,
+                                                                                         LoggingXProperties properties) {
+        log.info("Configurando LoggingX ServiceBusLoggingHelper");
+        return new com.hlaff.loggingx.servicebus.ServiceBusLoggingHelper(structuredLogger, properties);
+    }
+
+    // ========================================
     // CONECTORES MONGODB
     // ========================================
 
@@ -196,6 +210,28 @@ public class LoggingXAutoConfiguration {
     }
 
     // ========================================
+    // CONECTORES JDBC
+    // ========================================
+
+    @Bean
+    @ConditionalOnClass(net.ttddyy.dsproxy.support.ProxyDataSourceBuilder.class)
+    @ConditionalOnProperty(prefix = "loggingx.jdbc", name = "enabled", havingValue = "true")
+    @ConditionalOnMissingBean
+    public com.hlaff.loggingx.jdbc.LoggingQueryExecutionListener loggingQueryExecutionListener(StructuredLogger structuredLogger,
+                                                                                              LoggingXProperties properties) {
+        log.info("Configurando LoggingX LoggingQueryExecutionListener");
+        return new com.hlaff.loggingx.jdbc.LoggingQueryExecutionListener(structuredLogger, properties);
+    }
+
+    @Bean
+    @ConditionalOnClass(net.ttddyy.dsproxy.support.ProxyDataSourceBuilder.class)
+    @ConditionalOnProperty(prefix = "loggingx.jdbc", name = "enabled", havingValue = "true")
+    public com.hlaff.loggingx.jdbc.LoggingDataSourceProxyBeanPostProcessor loggingDataSourceProxyBeanPostProcessor(com.hlaff.loggingx.jdbc.LoggingQueryExecutionListener listener) {
+        log.info("Configurando LoggingX LoggingDataSourceProxyBeanPostProcessor");
+        return new com.hlaff.loggingx.jdbc.LoggingDataSourceProxyBeanPostProcessor(listener);
+    }
+
+    // ========================================
     // INFORMAÇÕES DE INICIALIZAÇÃO
     // ========================================
 
@@ -207,7 +243,9 @@ public class LoggingXAutoConfiguration {
         log.info("   Versão: {}", properties.getVersion());
         log.info("   HTTP habilitado: {}", properties.getHttp().isEnabled());
         log.info("   Kafka habilitado: {}", properties.getKafka().isEnabled());
+        log.info("   ServiceBus habilitado: {}", properties.getServicebus().isEnabled());
         log.info("   MongoDB habilitado: {}", properties.getMongo().isEnabled());
+        log.info("   JDBC habilitado: {}", properties.getJdbc().isEnabled());
         log.info("   Chaves para mascaramento: {}", properties.getRedactKeys().size());
         log.info("========================================");
     }

--- a/src/main/java/com/hlaff/loggingx/spring/config/LoggingXProperties.java
+++ b/src/main/java/com/hlaff/loggingx/spring/config/LoggingXProperties.java
@@ -62,6 +62,11 @@ public class LoggingXProperties {
     private KafkaSection kafka = new KafkaSection();
 
     /**
+     * Configurações específicas para Azure Service Bus
+     */
+    private ServiceBusSection servicebus = new ServiceBusSection();
+
+    /**
      * Configurações específicas para MongoDB
      */
     private MongoSection mongo = new MongoSection();
@@ -162,6 +167,37 @@ public class LoggingXProperties {
          * Se deve logar headers das mensagens
          */
         private boolean logHeaders = true;
+    }
+
+    /**
+     * Configurações para Azure Service Bus
+     */
+    @Data
+    public static class ServiceBusSection {
+        /**
+         * Se o conector Service Bus está habilitado
+         */
+        private boolean enabled = true;
+
+        /**
+         * Se deve logar envio de mensagens
+         */
+        private boolean logProducer = true;
+
+        /**
+         * Se deve logar recebimento de mensagens
+         */
+        private boolean logConsumer = true;
+
+        /**
+         * Se deve logar payload das mensagens
+         */
+        private boolean logPayload = false;
+
+        /**
+         * Se deve logar application properties das mensagens
+         */
+        private boolean logApplicationProperties = true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add JDBC query listener and DataSource proxy to log relational DB operations
- add Azure Service Bus logging helper and configuration
- document new connectors and dependencies

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab955771d8832483a47768b0959fff